### PR TITLE
Use protocol-relative jQuery link

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -7,7 +7,7 @@
         <meta name="description" content="">
         <link rel="stylesheet" href="portfolio.jquery.css">
 
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
         <script src="portfolio.jquery.js"></script>
 
         <script>


### PR DESCRIPTION
If viewing the page over HTTPS, Chrome refuses to load jQuery, so it's just a whole lot of nothing.
